### PR TITLE
fix: skip placeholder phase when glyph metrics are cached

### DIFF
--- a/packages/number-flow-react-native/src/native/NumberFlow.tsx
+++ b/packages/number-flow-react-native/src/native/NumberFlow.tsx
@@ -166,7 +166,7 @@ export const NumberFlow = ({
   const maskBottom = adaptiveMask.bottom;
   const { expansionTop, expansionBottom } = adaptiveMask;
 
-  const [slotsReady, setSlotsReady] = useState(false);
+  const [slotsReady, setSlotsReady] = useState(!!metrics);
   const metricsReady = !!metrics;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

When `NumberFlow` unmounts and remounts (like switching between tabs), `slotsReady` always starts as `false`. This forces 1-2 frames of a placeholder `<Text>` before the digit slots actually render. Since the placeholder uses native text kerning and the digit slots use individually measured `charWidths`, you get a visible layout shift on every remount.

## Fix

Initialize `slotsReady` based on whether `metrics` already exists:

```diff
- const [slotsReady, setSlotsReady] = useState(false);
+ const [slotsReady, setSlotsReady] = useState(!!metrics);

```
If metrics are already cached from a previous mount, the placeholder phase gets skipped completely. On the very first mount, metrics is still null so nothing changes.

Fixes #7