### PR TITLE
fix: prune exiting digit slot when its fade animation is interrupted

### DIFF
--- a/.changeset/prune-exiting-slot-on-interrupt.md
+++ b/.changeset/prune-exiting-slot-on-interrupt.md
@@ -1,0 +1,5 @@
+---
+"number-flow-react-native": patch
+---
+
+Prune exiting digit slots when their fade is interrupted. `useSlotOpacity` only reported completion on `finished: true`, so an interrupted exit left the key in `useLayoutDiff`'s `exitingRef` permanently and the stale glyph stayed mounted on top of the live one.

--- a/packages/number-flow-react-native/src/core/useSlotOpacity.ts
+++ b/packages/number-flow-react-native/src/core/useSlotOpacity.ts
@@ -48,7 +48,16 @@ export function useSlotOpacity({
         },
         (finished) => {
           "worklet";
-          if (finished && onExitComplete && exitKey) {
+          // Report completion even when the animation did NOT finish. An
+          // interrupted withTiming reports `finished: false`, and gating the
+          // callback on it leaks the slot: `useLayoutDiff` keeps the key in
+          // `exitingRef` until `onExitComplete` fires, so the exiting glyph stays
+          // mounted on top of the live one indefinitely.
+          //
+          // Pruning unconditionally is safe because `useLayoutDiff` deletes any
+          // key present in the current layout during its diff, so a slot that has
+          // re-entered is never removed by this path.
+          if (onExitComplete && exitKey) {
             runOnJS(onExitComplete)(exitKey);
           }
         },


### PR DESCRIPTION
## The bug

`useSlotOpacity` gates `onExitComplete` on `finished === true`:

```ts
(finished) => {
  "worklet";
  if (finished && onExitComplete && exitKey) {
    runOnJS(onExitComplete)(exitKey);
  }
},
```

An interrupted `withTiming` reports `finished: false`. `useLayoutDiff` keeps a key in `exitingRef` until `onExitComplete` fires for it, so when the fade is interrupted the key is **never** removed — the exiting glyph stays mounted on top of the live one indefinitely.

## Reproducing

Anything that cancels the exit fade mid-flight:

- change the value twice in quick succession, so a slot that is mid-exit is re-diffed
- any re-render/teardown that cancels the animation while it is running — in our case tapping a card that pushes a `formSheet` over the screen while the digits were still rolling

Result: every slot that was mid-exit is left permanently doubled — the hero number, a secondary line and a percentage all rendering two superimposed digit stacks (`2,238` over `2,276`, and so on). It does not recover, because nothing else prunes `exitingRef`.

## The fix

Report completion regardless of `finished`.

This is safe: `useLayoutDiff` already deletes any key present in the **current** layout during its diff —

```ts
for (const key of currentKeys) {
  exitingRef.current.delete(key);
}
```

— so a slot that has re-entered is never removed by this path. The callback only ever cleans up a slot that stopped animating, for whatever reason.

## Notes

- Verified on iOS (RN 0.83, Reanimated 4.5, `native` renderer) — the doubling was reproducible on demand before, and is gone after.
- Added a patch changeset.
- Happy to adjust the comment wording or split it if you would prefer a narrower guard (e.g. tracking cancellation explicitly rather than pruning on any non-finish).
