### PR TITLE
docs: add troubleshooting guide for RN 0.84+ prebuilt-core linker errors

### DIFF
--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -137,6 +137,10 @@ pnpm add @rednegniw/masked-view
 <Callout type="warn">
 Both masked-view options require a dev build (Expo Dev Client or bare RN). They won't work in Expo Go; the native renderer will automatically fall back to per-digit opacity fading in those environments.
 </Callout>
+
+<Callout type="info">
+Hitting an iOS linker error mentioning `DebugStringConvertible` or `Sealable` on React Native 0.84+? See [Troubleshooting](/docs/guides/troubleshooting).
+</Callout>
 </Step>
 
 </Steps>

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Guides",
-  "pages": ["accessibility", "performance-tips"]
+  "pages": ["accessibility", "performance-tips", "troubleshooting"]
 }

--- a/docs/content/docs/guides/troubleshooting.mdx
+++ b/docs/content/docs/guides/troubleshooting.mdx
@@ -1,0 +1,29 @@
+---
+title: Troubleshooting
+description: Fixes for known build and runtime issues
+full: true
+---
+
+## iOS linker error: `DebugStringConvertible` / `Sealable` undefined symbols (RN 0.84+)
+
+On React Native 0.84 and newer, iOS links against a prebuilt React core framework by default. Its Release flavor is compiled with `NDEBUG`, which removes debug-only C++ symbols like `facebook::react::DebugStringConvertible` and `facebook::react::Sealable`. When the prebuilt core on disk doesn't match your build configuration (stale `Pods/` state, an interrupted build, or a CocoaPods cache carrying over an old extraction), every Fabric library built from source fails to link with errors like:
+
+```
+Undefined symbols for architecture arm64:
+  "facebook::react::Sealable::Sealable()", referenced from:
+      facebook::react::NFMaskedViewProps::NFMaskedViewProps() in libNFMaskedView.a(NFMaskedViewComponentView.o)
+```
+
+This is not specific to `@rednegniw/masked-view`: the same error hits any from-source Fabric component (it's just often the first one in an otherwise JS-only app). To fix it, reset the pods state so the correct core flavor is re-extracted:
+
+```bash
+cd ios
+rm -rf Pods build
+pod install
+```
+
+Then clean the build folder in Xcode (Product > Clean Build Folder) and rebuild.
+
+<Callout type="warn">
+Don't work around this by defining `REACT_NATIVE_PRODUCTION=1` in your Podfile. It silences the linker error but creates an ABI mismatch in `ViewProps` that crashes at runtime. Also make sure your Podfile calls `react_native_post_install(installer, ...)` in `post_install`; it aligns compiler flags with the prebuilt core in Release builds.
+</Callout>


### PR DESCRIPTION
Adds a Troubleshooting page to the docs covering the iOS linker error reported in #14 (`DebugStringConvertible` / `Sealable` undefined symbols when building with React Native 0.84+).

Investigation showed the error is not caused by `@rednegniw/masked-view`: a clean RN 0.85.3 app with the package builds fine. The failure occurs when a stale `Pods/` state leaves the wrong flavor of the prebuilt React core on disk, which breaks linking for any from-source Fabric library (reproduced against `react-native-safe-area-context` and `ReactCodegen` as well). See facebook/react-native#57293 for the upstream discussion.

- New `guides/troubleshooting.mdx` page explaining the error, its cause, the clean-pods fix, and a warning against the `REACT_NATIVE_PRODUCTION=1` workaround (it introduces a `ViewProps` ABI mismatch that crashes at runtime)
- Registers the page in `guides/meta.json` navigation
- Adds an info callout in `getting-started.mdx` next to the MaskedView install step linking to the new page