### PR TITLE
docs: point Sandpack live examples at 0.5.0

### DIFF
--- a/docs/src/components/live-example/sandpack-config.ts
+++ b/docs/src/components/live-example/sandpack-config.ts
@@ -2,7 +2,7 @@ export const SANDPACK_DEPENDENCIES: Record<string, string> = {
   "react-native-web": "~0.19.13",
   "react-native-reanimated": "~4.1.0",
   "react-native-worklets": "~0.7.0",
-  "number-flow-react-native": "^0.3.0",
+  "number-flow-react-native": "^0.5.0",
 };
 
 export const VITE_CONFIG_CODE = `import { defineConfig } from "vite";


### PR DESCRIPTION
Bumps the live-example Sandpack dependency to the just-published number-flow-react-native@0.5.0 so the docs playground runs the release with the performance overhaul and the masked-view fallback.