### PR TITLE
fix: accept string `fontVariant` from react-native 0.87

### DIFF
--- a/packages/number-flow-react-native/src/native/glyphMetricsShared.ts
+++ b/packages/number-flow-react-native/src/native/glyphMetricsShared.ts
@@ -17,12 +17,15 @@ export function cacheKey(
   style: {
     fontFamily?: string;
     fontSize: number;
-    fontVariant?: string[];
+    // react-native 0.87 widened TextStyle["fontVariant"] to also accept a plain string
+    fontVariant?: readonly string[] | string;
     fontWeight?: string | number;
   },
   additionalChars?: string,
 ): string {
-  const variant = style.fontVariant?.join(",") ?? "";
+  const variant = Array.isArray(style.fontVariant)
+    ? style.fontVariant.join(",")
+    : (style.fontVariant ?? "");
   const weight = style.fontWeight ?? "";
   const base = `${style.fontFamily}:${style.fontSize}:${variant}:${weight}`;
   return additionalChars ? `${base}:${additionalChars}` : base;


### PR DESCRIPTION
React Native 0.87 widened `TextStyle["fontVariant"]`: it now also accepts a plain string. `glyphMetricsShared.ts` still types it as `string[]` and calls `.join(",")` unconditionally, so a `TextStyle`-typed style stops typechecking against the library on 0.87, and a string value would produce a wrong glyph cache key at runtime (`.join` isn't a thing on strings).

This PR widens the type to `readonly string[] | string` and builds the cache key with an `Array.isArray` check. Output for arrays stays byte for byte the same.

We've been running this change as a package patch on 0.4.2 since upgrading our app to react-native 0.87.0. Typecheck passes and the animated numbers render as before.
