### PR TITLE
fix(native): give the digit strip real layout metrics so recycled Fabric views can't freeze digits

### DIFF
--- a/.changeset/frozen-digits-recycled-views.md
+++ b/.changeset/frozen-digits-recycled-views.md
@@ -1,0 +1,20 @@
+---
+"number-flow-react-native": patch
+---
+
+Fix digits freezing mid-roll or disappearing when a slot mounts on a recycled Fabric view
+
+The native renderer's digit strip was an absolutely-positioned view at the
+origin with only absolutely-positioned children, so its layout metrics were
+exactly `{0,0,0,0}`. On Fabric, `RCTViewComponentView.prepareForRecycle`
+resets stored metrics to zeroed values rather than the `EmptyLayoutMetrics`
+sentinel, so when a newly mounted strip received a recycled native view its
+zero frame compared equal and the frame assignment was skipped - the strip
+kept the recycled donor's frame and digits drew displaced or outside the clip
+window (frozen half-glyphs, invisible digits) until the next React commit
+happened to rewrite the subtree.
+
+The strip now lays out as a real box sized to its digit column
+(`maxDigitWidth` x strip length, offset up by the pad, digits at non-negative
+offsets inside), so its layout metrics are never all-zero and every mount
+applies a correct frame.

--- a/.changeset/frozen-digits-recycled-views.md
+++ b/.changeset/frozen-digits-recycled-views.md
@@ -6,13 +6,16 @@ Fix digits freezing mid-roll or disappearing when a slot mounts on a recycled Fa
 
 The native renderer's digit strip was an absolutely-positioned view at the
 origin with only absolutely-positioned children, so its layout metrics were
-exactly `{0,0,0,0}`. On Fabric, `RCTViewComponentView.prepareForRecycle`
-resets stored metrics to zeroed values rather than the `EmptyLayoutMetrics`
-sentinel, so when a newly mounted strip received a recycled native view its
-zero frame compared equal and the frame assignment was skipped - the strip
-kept the recycled donor's frame and digits drew displaced or outside the clip
-window (frozen half-glyphs, invisible digits) until the next React commit
-happened to rewrite the subtree.
+exactly `{0,0,0,0}`. On Fabric, a recycled `RCTViewComponentView` compares
+incoming layout metrics against its stored ones rather than the
+`EmptyLayoutMetrics` sentinel, and those stored metrics can be all-zero too:
+React Native 0.85+ resets them to zero-initialized values in
+`prepareForRecycle`, while older versions retain the donor view's metrics,
+which may themselves be zero. A strip whose true layout is all-zero compared
+equal, the frame assignment was skipped, and the strip kept the recycled
+donor's frame - digits drew displaced or outside the clip window (frozen
+half-glyphs, invisible digits) until the next React commit happened to
+rewrite the subtree.
 
 The strip now lays out as a real box sized to its digit column
 (`maxDigitWidth` x strip length, offset up by the pad, digits at non-negative

--- a/packages/number-flow-react-native/src/native/DigitSlot.tsx
+++ b/packages/number-flow-react-native/src/native/DigitSlot.tsx
@@ -292,12 +292,34 @@ export const DigitSlot = React.memo(
       [stripY],
     );
 
+    /**
+     * Real dimensions for the strip. A view whose layout metrics are exactly
+     * {0,0,0,0} is indistinguishable from a recycled RCTViewComponentView's
+     * reset metrics (prepareForRecycle stores zeroed metrics, not the
+     * EmptyLayoutMetrics sentinel), so Fabric skips the frame assignment at
+     * mount and the view keeps the recycled donor's frame - digits then draw
+     * displaced or outside the clip window until the next React commit.
+     * Sizing the strip to its digit column (offset up by the pad, digits at
+     * non-negative tops inside) guarantees non-zero metrics. Width must be
+     * maxDigitWidth, not an arbitrary token: absolutely-positioned digit
+     * texts measure against the strip as their containing block, and a
+     * narrower box would wrap or clip wide glyphs.
+     */
+    const stripBoxStyle = useMemo(
+      () => ({
+        top: -STRIP_PAD * effectiveLH,
+        width: metrics.maxDigitWidth,
+        height: stripLength * effectiveLH,
+      }),
+      [effectiveLH, stripLength, metrics.maxDigitWidth],
+    );
+
     const digitElements = useMemo(
       () =>
         Array.from({ length: stripLength }, (_, i) => {
           const digitString =
             resolvedDigitStrings[wheelStripDigit(i, STRIP_PAD, resolvedDigitCount)];
-          const top = (i - STRIP_PAD) * effectiveLH;
+          const top = i * effectiveLH;
 
           return PER_DIGIT_FADE ? (
             <FadingStripDigit
@@ -328,7 +350,9 @@ export const DigitSlot = React.memo(
 
     return (
       <Animated.View style={[styles.slotClip, animatedSlotStyle]}>
-        <Animated.View style={[styles.strip, stripStyle]}>{digitElements}</Animated.View>
+        <Animated.View style={[styles.strip, stripBoxStyle, stripStyle]}>
+          {digitElements}
+        </Animated.View>
       </Animated.View>
     );
   },
@@ -344,7 +368,6 @@ const styles = StyleSheet.create({
   strip: {
     position: "absolute",
     left: 0,
-    top: 0,
   },
   digitText: {
     position: "absolute",


### PR DESCRIPTION
On Fabric, digits could freeze mid-roll or disappear entirely when a digit slot mounted while other views were being unmounted in the same transaction. The 0.5.0 native renderer's wheel strip laid out as an absolutely-positioned view at the origin with only absolutely-positioned children, so its Yoga layout metrics were exactly `{0,0,0,0}`. React Native's `RCTViewComponentView.prepareForRecycle` resets a recycled view's stored metrics to zeroed values rather than the `EmptyLayoutMetrics` sentinel (frame size `-1x-1`), and the base `updateLayoutMetrics` only assigns a frame when the old metrics equal the sentinel or the frames differ. A strip whose true layout is all-zero therefore compared equal to a recycled view's reset metrics, the frame assignment was skipped, and the strip kept the recycled donor's frame - digits drew displaced or outside the clip window until an unrelated React commit rewrote the subtree. The stuck state appeared as numbers frozen mid-roll, half-rendered glyphs between digit cells, or missing digits, anywhere a value change coincided with a sheet closing or list rows unmounting.

The strip now lays out as a real box sized to its digit column, so its layout metrics can never be all-zero and every mount applies a correct frame. The box is `maxDigitWidth` wide deliberately: the absolutely-positioned digit texts measure against the strip as their containing block, and any narrower box (for example a nominal `1x1`) clamps glyph measurement and wraps or clips wide digits, while `maxDigitWidth` fits every glyph by definition.

- `src/native/DigitSlot.tsx`: the strip gets explicit dimensions (`width: maxDigitWidth`, `height: stripLength * lineHeight`) and a `top: -STRIP_PAD * lineHeight` offset; digit texts move to non-negative `top` offsets inside the box (`i * lineHeight` instead of `(i - STRIP_PAD) * lineHeight`), preserving identical on-screen geometry.
- `.changeset/frozen-digits-recycled-views.md`: patch changeset describing the bug and the fix.

The Skia renderer is unaffected (it draws digits on a canvas rather than through per-digit native views). The underlying recycled-metrics behaviour is arguably a React Native bug (`prepareForRecycle` restoring zeroed metrics instead of the sentinel), but the renderer no longer depends on that being fixed upstream.
