### PR TITLE
docs: point Sandpack live examples at number-flow-react-native 0.5.1

### DIFF
--- a/docs/src/components/live-example/sandpack-config.ts
+++ b/docs/src/components/live-example/sandpack-config.ts
@@ -2,7 +2,7 @@ export const SANDPACK_DEPENDENCIES: Record<string, string> = {
   "react-native-web": "~0.19.13",
   "react-native-reanimated": "~4.1.0",
   "react-native-worklets": "~0.7.0",
-  "number-flow-react-native": "^0.5.0",
+  "number-flow-react-native": "^0.5.1",
 };
 
 export const VITE_CONFIG_CODE = `import { defineConfig } from "vite";


### PR DESCRIPTION
Bumps the Sandpack live-example dependency to the just-released 0.5.1 so the docs playground picks up the recycled-Fabric-view digit fix.

- `docs/src/components/live-example/sandpack-config.ts`: `number-flow-react-native` `^0.5.0` -> `^0.5.1`