### PR TITLE
chore: add changeset for string fontVariant fix

### DIFF
--- a/.changeset/accept-string-font-variant.md
+++ b/.changeset/accept-string-font-variant.md
@@ -1,0 +1,5 @@
+---
+"number-flow-react-native": patch
+---
+
+Accept a string `fontVariant` from React Native 0.87 `TextStyle` when building the glyph-metrics cache key, instead of assuming an array and calling `.join()` (#24)


### PR DESCRIPTION
## Summary
- Adds a patch changeset for #24 so the string `fontVariant` cache-key fix is included in the next release.

## Test plan
- [x] Changeset file targets `number-flow-react-native` as `patch`
- [ ] Confirm the Version Packages PR picks it up after merge


Made with [Cursor](https://cursor.com)